### PR TITLE
Fix radius circumferential mesh division settings

### DIFF
--- a/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
+++ b/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
@@ -618,8 +618,8 @@ class BSPM_EM_Analyzer:
 
         study.GetMeshControl().SetValue("MeshType", 1)  # make sure this has been exe'd:
         # study.GetCondition(u"RotCon").AddSet(model.GetSetList().GetSet(u"Motion_Region"), 0)
-        study.GetMeshControl().SetValue(u"AutoGapDivision", 0)  # this is new line
-        study.GetMeshControl().SetValue(u"AutoDivision", 0)  # this is new line
+        study.GetMeshControl().SetValue(u"AutoGapDivision", 0)  # this is new line April-17-2026
+        study.GetMeshControl().SetValue(u"AutoDivision", 0)  # this is new line April-17-2026
         study.GetMeshControl().SetValue(
             "RadialDivision", self.config.airgap_mesh_radial_div
         )  # for air region near which motion occurs

--- a/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
+++ b/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
@@ -618,8 +618,8 @@ class BSPM_EM_Analyzer:
 
         study.GetMeshControl().SetValue("MeshType", 1)  # make sure this has been exe'd:
         # study.GetCondition(u"RotCon").AddSet(model.GetSetList().GetSet(u"Motion_Region"), 0)
-        study.GetMeshControl().SetValue(u"AutoGapDivision", 0)  # this is new line April-17-2026
-        study.GetMeshControl().SetValue(u"AutoDivision", 0)  # this is new line April-17-2026
+        study.GetMeshControl().SetValue(u"AutoGapDivision", 0)
+        study.GetMeshControl().SetValue(u"AutoDivision", 0)
         study.GetMeshControl().SetValue(
             "RadialDivision", self.config.airgap_mesh_radial_div
         )  # for air region near which motion occurs

--- a/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
+++ b/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
@@ -618,6 +618,8 @@ class BSPM_EM_Analyzer:
 
         study.GetMeshControl().SetValue("MeshType", 1)  # make sure this has been exe'd:
         # study.GetCondition(u"RotCon").AddSet(model.GetSetList().GetSet(u"Motion_Region"), 0)
+        study.GetMeshControl().SetValue(u"AutoGapDivision", 0)  # this is new line
+        study.GetMeshControl().SetValue(u"AutoDivision", 0)  # this is new line
         study.GetMeshControl().SetValue(
             "RadialDivision", self.config.airgap_mesh_radial_div
         )  # for air region near which motion occurs


### PR DESCRIPTION
This PR fixes radius and circumferential mesh division settings to close #362.

# Notes

Here is the confirmation after running the `examples/mach_eval_examples/bspm_eval/bspm_evaluator.py`.

<img width="1762" height="1557" alt="Screenshot 2026-04-17 155636" src="https://github.com/user-attachments/assets/2edd1dcb-64fb-4bd5-b548-de4d621f5fd1" />

The mesh is now generated properly as described in the issue discriotion [here](https://github.com/Severson-Group/eMach/issues/362).