### PR TITLE
Add changelog notes for v1.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This document summarizes the changes introduced to the code base for each release.
 
+## v1.3.1
+
+- Fix BSPM analyzer mesh division settings
+- Fix BSPM analyzer doc to match v1.2.0 feature
+- Fix ubuntu runner for eMachPrivate docs
+
 ## v1.3.0
 
 - Add mach_cad ability to move solid parts


### PR DESCRIPTION
This PR adds the release notes for upcoming release `v1.3.1`, following step 6 of the [eMach release procedure](https://emach.readthedocs.io/en/v1.3.0/maintainer.html).

## Issues addressed in this release
- #363
- #362
- #365

## Previous release PR
- #361 